### PR TITLE
Python2

### DIFF
--- a/bin/tabview
+++ b/bin/tabview
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 """ tabview -- View a tab-delimited file in a spreadsheet-like display.
   Scott Hansen <firecat four one five three at gmail dot com>
@@ -15,6 +16,7 @@
           t.view(fn=<filename>[, enc=<encoding>])
 
 """
+from __future__ import print_function, unicode_literals
 import argparse
 from tabview.tabview import readme, view
 

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -1,9 +1,12 @@
+# -*- coding: utf-8 -*-
 """ tabview.py -- View a tab-delimited file in a spreadsheet-like display.
 
   Scott Hansen <firecat four one five three at gmail dot com>
   Based on code contributed by A.M. Kuchling <amk at amk dot ca>
 
 """
+from __future__ import print_function, division, unicode_literals
+
 import csv
 import curses
 import _curses
@@ -15,6 +18,33 @@ import sys
 from operator import itemgetter
 from subprocess import Popen, PIPE
 from textwrap import wrap
+
+
+if sys.version_info.major < 3:
+    # Python 2.7 shim
+    str = unicode
+
+    def addstr(*args):
+        scr, args = args[0], list(args[1:])
+        x = 2 if len(args) > 2 else 0
+        args[x] = args[x].encode(sys.stdout.encoding)
+        return scr.addstr(*args)
+
+    def insstr(*args):
+        scr, args = args[0], list(args[1:])
+        x = 2 if len(args) > 2 else 0
+        args[x] = args[x].encode(sys.stdout.encoding)
+        return scr.insstr(*args)
+
+else:
+    # Python 3 wrappers
+    def addstr(*args):
+        scr, args = args[0], args[1:]
+        return scr.addstr(*args)
+
+    def insstr(*args):
+        scr, args = args[0], args[1:]
+        return scr.insstr(*args)
 
 
 class Viewer:
@@ -225,7 +255,7 @@ class Viewer:
             lines = len(s) + 2
             scr2 = curses.newwin(lines, 80, 5, 5)
             scr2.move(0, 0)
-            scr2.addstr(1, 1, "\n".join(s))
+            addstr(scr2, 1, 1, "\n".join(s))
             scr2.box()
             while not scr2.getch():
                 pass
@@ -236,7 +266,7 @@ class Viewer:
             scr2 = curses.newwin(4, 40, 15, 15)
             scr2.box()
             scr2.move(1, 1)
-            scr2.addstr("Search: ")
+            addstr(scr2, "Search: ")
             curses.echo()
             search = scr2.getstr().decode(sys.stdout.encoding).lower()
             curses.noecho()
@@ -277,7 +307,7 @@ class Viewer:
             lines = len(help_txt) + 2
             scr2 = curses.newwin(lines, 82, 5, 5)
             scr2.move(0, 0)
-            scr2.addstr(1, 1, " ".join(help_txt))
+            addstr(scr2, 1, 1, " ".join(help_txt))
             scr2.box()
             while not scr2.getch():
                 pass
@@ -511,12 +541,12 @@ class Viewer:
         self.scr.move(0, 0)
         self.scr.clrtoeol()
         s = "  {},{}  ".format(yp + 1, xp + 1)
-        self.scr.addstr(s, curses.A_REVERSE)
+        addstr(self.scr, s, curses.A_REVERSE)
 
         # Adds the current cell content after the 'current cell' display
-        wc = self.max_x - len(s) - 1
+        wc = self.max_x - len(s) - 2
         s = self.cellstr(yp, xp, wc)
-        self.scr.addstr(" " + s, curses.A_NORMAL)
+        addstr(self.scr, "  " + s, curses.A_NORMAL)
 
         # Print a divider line
         self.scr.hline(1, 0, curses.ACS_HLINE, self.max_x)
@@ -528,7 +558,7 @@ class Viewer:
             for x in range(0, self.vis_columns):
                 xc, wc = self.column_xw(x)
                 s = self.hdrstr(x + self.win_x, wc)
-                self.scr.insstr(self.header_offset - 1, xc, s, curses.A_BOLD)
+                insstr(self.scr, self.header_offset - 1, xc, s, curses.A_BOLD)
 
         # Print the table data
         for y in range(0, self.max_y - self.header_offset):
@@ -541,7 +571,7 @@ class Viewer:
                     attr = curses.A_NORMAL
                 xc, wc = self.column_xw(x)
                 s = self.cellstr(y + self.win_y, x + self.win_x, wc)
-                self.scr.insstr(y + self.header_offset, xc, s, attr)
+                insstr(self.scr, y + self.header_offset, xc, s, attr)
 
         self.scr.refresh()
 
@@ -560,7 +590,7 @@ class Viewer:
         if len(self.header) <= x:
             s = ""
         else:
-            s = str(self.header[x])
+            s = self.header[x]
         return self.strpad(s, width)
 
     def cellstr(self, y, x, width):
@@ -568,32 +598,30 @@ class Viewer:
         if len(self.data) <= y or len(self.data[y]) <= x:
             s = ""
         else:
-            s = str(self.data[y][x])
+            s = self.data[y][x]
         return self.strpad(s, width)
 
 
 def csv_sniff(fn, enc):
-    """Given a filename or a list of lists, sniff the dialect of the
-    file and return the delimiter. This should keep any errors from
-    popping up with tab or comma delimited files.
+    """Given a filename or a list of lists, sniff the dialect of the file and
+    return it. This should keep any errors from popping up with tab or comma
+    delimited files.
 
     Args:
         fn - complete file path/name or list like
             ["col1,col2,col3","data1,data2,data3","data1...]
         enc - python encoding value ('utf_8','latin-1','cp870', etc)
     Returns:
-        delimiter - ',' or '\t' or other delimiter
+        csv.dialect
 
     """
-    try:
-        # If fn is a filename
-        with open(fn, 'r', encoding=enc) as f:
-            dialect = csv.Sniffer().sniff(f.readline())
-            return dialect.delimiter
-    except TypeError:
-        # If fn is a list, check the first item in the list
-        dialect = csv.Sniffer().sniff(fn[0])
-        return dialect.delimiter
+    if sys.version_info.major < 3:
+        with open(fn, 'rb') as f:
+            dialect = csv.Sniffer().sniff(f.read(1024 * 4))
+    else:
+        with open(fn, 'r', encoding=enc, newline='') as f:
+            dialect = csv.Sniffer().sniff(f.read(1024 * 4))
+    return dialect
 
 
 def main(stdscr, data):
@@ -602,17 +630,26 @@ def main(stdscr, data):
     Viewer(stdscr, data).run()
 
 
-def process_file(fn, enc=None):
+def process_file(fn, enc=None, dialect=None):
     """Given a filename, return the file as a list of lists.
 
     """
     if enc is None:
-        enc = set_encoding(fn)
+        enc = detect_encoding(fn)
+    if dialect is None:
+        dialect = csv_sniff(fn, enc)
     data = []
-    with open(fn, 'r', encoding=enc) as f:
-        csv_obj = csv.reader(f, delimiter=csv_sniff(fn, enc))
-        for row in csv_obj:
-            data.append(row)
+    if sys.version_info.major < 3:
+        with open(fn, 'rb') as f:
+            csv_obj = csv.reader(f, dialect=dialect)
+            for row in csv_obj:
+                row = map(lambda x: str(x, enc), row)
+                data.append(row)
+    else:
+        with open(fn, 'r', encoding=enc, newline='') as f:
+            csv_obj = csv.reader(f, dialect=dialect)
+            for row in csv_obj:
+                data.append(row)
     return data
 
 
@@ -623,7 +660,7 @@ def readme():
         return f.readlines()
 
 
-def set_encoding(fn=None):
+def detect_encoding(fn=None):
     """Return the default system encoding. If a filename is passed, try
     to decode the file with the default system encoding or from a short
     list of encoding types to test.
@@ -637,15 +674,14 @@ def set_encoding(fn=None):
     """
     enc_list = ['UTF-8', 'LATIN-1', 'iso8859-1', 'iso8859-2',
                 'UTF-16', 'CP720']
-    locale.setlocale(locale.LC_ALL, '')
-    code = locale.getpreferredencoding()
+    code = locale.getpreferredencoding(False)
     if code not in enc_list:
         enc_list.insert(0, code)
     if fn is not None:
         for c in enc_list:
             try:
-                with open(fn, 'r', encoding=c) as f:
-                    f.read()
+                with open(fn, 'rb') as f:
+                    f.readline().decode(c)
             except (UnicodeDecodeError, UnicodeError):
                 continue
             return c
@@ -667,12 +703,17 @@ def view(data=None, fn=None, enc=None):
         enc: encoding for file
 
     """
-    while True:
+    if sys.version_info.major < 3:
+        lc_all = locale.getlocale(locale.LC_ALL)
+        locale.setlocale(locale.LC_ALL, '')
+    else:
+        lc_all = None
+    try:
         if data is not None:
             d = data
         elif fn is not None:
             d = process_file(fn, enc)
-        try:
-            curses.wrapper(main, d)
-        except _curses.error:
-            continue
+        curses.wrapper(main, d)
+    finally:
+        if lc_all is not None:
+            locale.setlocale(locale.LC_ALL, lc_all)

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -469,7 +469,7 @@ class Viewer:
             # Since .isdigit() doesn't exist if c > 256, we need to catch the
             # error for those keys.
             found_digit = False
-        if found_digit:
+        if found_digit and (len(self.modifier) > 0 or c not in self.keys):
             self.handle_modifier(c)
         elif c in self.keys:
             self.keys[c]()

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -609,10 +609,10 @@ def csv_sniff(fn, enc):
     """
     if sys.version_info.major < 3:
         with open(fn, 'rb') as f:
-            dialect = csv.Sniffer().sniff(f.read(1024 * 4))
+            dialect = csv.Sniffer().sniff(f.read(1024 * 8))
     else:
         with open(fn, 'r', encoding=enc, newline='') as f:
-            dialect = csv.Sniffer().sniff(f.read(1024 * 4))
+            dialect = csv.Sniffer().sniff(f.read(1024 * 8))
     return dialect
 
 

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -9,7 +9,6 @@ from __future__ import print_function, division, unicode_literals
 
 import csv
 import curses
-import _curses
 import locale
 import os
 import os.path

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -470,36 +470,22 @@ class Viewer:
             # Since .isdigit() doesn't exist if c > 256, we need to catch the
             # error for those keys.
             found_digit = False
-        has_modifier = not self.modifier == str()
-        try:
-            if found_digit and has_modifier:
-                # Add the digit to the modifier rather than executing a command
-                self.handle_modifier(c)
-            else:
-                self.keys[c]()
-        except KeyError:
-            # Ignore incorrect keys
+        if found_digit:
             self.handle_modifier(c)
+        elif c in self.keys:
+            self.keys[c]()
         else:
-            if not found_digit:
-                # Don't clear the modifier if we the last character was a digit
-                self.modifier = str()
+            self.modifier = str()
 
     def handle_modifier(self, mod):
         """Append digits as a key modifier, clear the modifier if not
         a digit.
 
         Args:
-            mod: potential modifier key
+            mod: potential modifier string
         """
-        self.scr.refresh()
-        try:
-            if mod.isdigit():
-                self.modifier = "{}{}".format(self.modifier, mod)
-            else:
-                self.modifier = str()
-        except AttributeError:
-            # Ignore illegal keys
+        self.modifier += mod
+        if not self.modifier.isdigit():
             self.modifier = str()
 
     def resize(self):

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -700,17 +700,18 @@ def view(data=None, fn=None, enc=None):
         locale.setlocale(locale.LC_ALL, '')
     else:
         lc_all = None
-    while True:
-        try:
-            if data is not None:
-                d = data
-            elif fn is not None:
-                d = process_file(fn, enc)
-            curses.wrapper(main, d)
-        except QuitException:
-            return
-        except ReloadException:
-            continue
-        finally:
-            if lc_all is not None:
-                locale.setlocale(locale.LC_ALL, lc_all)
+    try:
+        while True:
+            try:
+                if data is not None:
+                    d = data
+                elif fn is not None:
+                    d = process_file(fn, enc)
+                curses.wrapper(main, d)
+            except QuitException:
+                return
+            except ReloadException:
+                continue
+    finally:
+        if lc_all is not None:
+            locale.setlocale(locale.LC_ALL, lc_all)


### PR DESCRIPTION
From the commit message:

- Make the environment as similar as Python 3 as possible
- Fill the gaps using addstr/insstr shims
- Do not change locale unless when using Python 2.7 (which requires it for curses),
  and restore it when returning from view.
- Different paths for the "csv" module, as it seems irreversibly incompatible.
- Just use the unicode.decode function on a binary stream to check the conversion.

It expands on your initial commit. It's mostly transparent (as I intentionally make python 2.7 work as python 3 does). CSV in python 2.7 doesn't play well with the codec library at various points, so for that I *had* to make separate code paths.

One thing that still doesn't work is changing the column width/gap, though it seems totally unrelated to the I/O.

I also noticed the key handling is a bit... odd. There's a spurious scr.refresh() call in handle_modifier() that shouldn't be there, but I guess I'm going to fix that in a separate commit, hoping to fix the column gap thing together.