### PR TITLE
Read entire file to determine encoding.

### DIFF
--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -677,7 +677,8 @@ def detect_encoding(fn=None):
         for c in enc_list:
             try:
                 with open(fn, 'rb') as f:
-                    f.readline().decode(c)
+                    for line in f.readlines():
+                        line.decode(c)
             except (UnicodeDecodeError, UnicodeError):
                 continue
             return c

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -673,18 +673,20 @@ def detect_encoding(fn=None):
     code = locale.getpreferredencoding(False)
     if code not in enc_list:
         enc_list.insert(0, code)
-    if fn is not None:
-        for c in enc_list:
-            try:
-                with open(fn, 'rb') as f:
-                    for line in f.readlines():
-                        line.decode(c)
-            except (UnicodeDecodeError, UnicodeError):
-                continue
-            return c
-        print("Encoding not detected. Please pass encoding value manually")
-    else:
+    data = []
+    if fn is None:
         return code
+    with open(fn, 'rb') as f:
+        for line in f.readlines():
+            data.append(line)
+    for c in enc_list:
+        try:
+            for line in data:
+                line.decode(c)
+        except (UnicodeDecodeError, UnicodeError):
+            continue
+        return c
+    print("Encoding not detected. Please pass encoding value manually")
 
 
 def main(stdscr, data):


### PR DESCRIPTION
I had this setup initially, but then in the python 2.7 upgrade, we stopped scanning the entire file in detect_encoding(), and instead only scanned one line. I work with a lot of text files generated on Windows that sometimes won't have a Latin-1 character until deep into the file, causing tabview to fail during startup.(process_file()).

The 'encoding' branch has the simple fix (tested on both python2 and pythone3). Downside is that it slows down startup, but I don't know another way to detect a different encoding later in the file. For a 280MB text file with about 500k lines, it takes about 2 extra sec on my i5 laptop to scan the file for encoding.

Any other thoughts on this? @wavexx you seem to be more adept than I am at Unicode issues :)