### PR TITLE
Further increase the size of the csv_sniff window to determine delimiter

### DIFF
--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -607,10 +607,10 @@ def csv_sniff(fn, enc):
     """
     if sys.version_info.major < 3:
         with open(fn, 'rb') as f:
-            dialect = csv.Sniffer().sniff(f.read(1024 * 8))
+            dialect = csv.Sniffer().sniff(f.read(1024 * 32))
     else:
         with open(fn, 'r', encoding=enc, newline='') as f:
-            dialect = csv.Sniffer().sniff(f.read(1024 * 8))
+            dialect = csv.Sniffer().sniff(f.read(1024 * 32))
     return dialect
 
 


### PR DESCRIPTION
@wavexx you already raised this once. I have to raise it again to read a file I'm working with. Do we just raise it again if someone else has an even bigger file, or is there a better way to handle this?