### PR TITLE
Choose a fallback trunc_char if LC_CTYPE cannot represent it.

### DIFF
--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -78,7 +78,13 @@ class Viewer:
             self.header_offset = self.header_offset_orig - 1
         self.column_width = column_width
         self.column_gap = column_gap
-        self.trunc_char = trunc_char
+
+        try:
+            trunc_char.encode(sys.stdout.encoding)
+            self.trunc_char = trunc_char
+        except (UnicodeDecodeError, UnicodeError):
+            self.trunc_char = '>'
+
         self.x, self.y = 0, 0
         self.win_x, self.win_y = 0, 0
         self.max_y, self.max_x = 0, 0


### PR DESCRIPTION
This allows tabview to be used with the POSIX locale as long as the data does not contain unrepresentable characters.

It's incomplete, but it's a start.