### PR TITLE
Improve column width calculations when using 'mode'

### DIFF
--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -88,8 +88,8 @@ class Viewer:
             self.header_offset = self.header_offset_orig - 1
         self.num_data_columns = len(self.data[0])
         self.column_width_mode = column_width
-        self._get_column_widths(column_width)
         self.column_gap = column_gap
+        self._get_column_widths(column_width)
 
         try:
             trunc_char.encode(sys.stdout.encoding or 'utf-8')
@@ -677,11 +677,7 @@ class Viewer:
             Returns: mode - int. Minimum column width of 3
 
         """
-        if len(x) > 500:  # 500 is just arbitrary choice for "long"
-            # Check every 10th row for long columns
-            lens = [len(i) for i in x[::10]]
-        else:
-            lens = [len(i) for i in x]
+        lens = [len(i) for i in x]
         m = Counter(lens).most_common()
         # If there are a lot of empty columns, use the 2nd most common length
         # besides 0
@@ -690,10 +686,11 @@ class Viewer:
         except IndexError:
             mode = 0
         max_len = max(lens) or 1
-        if (max(3, (abs(mode - max_len))/max_len)) > 0.1:
-            return max(3, mode)
+        diff = abs(mode - max_len)
+        if diff > (self.column_gap * 2) and diff / max_len > 0.1:
+            return max(max(1, self.column_gap), mode)
         else:
-            return max(3, max_len)
+            return max(max(1, self.column_gap), max_len)
 
     def _get_column_widths_mode(self, d):
         """Given a list of lists, return a list of the variable column width


### PR DESCRIPTION
After experimenting a bit with some of my data files, I fiddled with the mode calculations.

First, you cannot calculate the mode on only a subset of the data. This fails flatly to calculate the correct width in many cases. If there's a significant drop in performance, there a couple of better ways to optimize the mode calculation we could use (including clustering widths to decrease the size of the counters).

I waived the restriction of 3 chars as the minimal column width (setting 1) using the current column_gap instead. This allows to get thinner widths if we also have a thin gap (1/0 char).