### PR TITLE
Show column label (if available) in the info bar.

### DIFF
--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -585,10 +585,16 @@ class Viewer:
         """Refresh the current display"""
         yp = self.y + self.win_y
         xp = self.x + self.win_x
+
         # Print the current cursor cell in the top left corner
         self.scr.move(0, 0)
         self.scr.clrtoeol()
-        s = "  {},{}  ".format(yp + 1, xp + 1)
+        ys = str(yp + 1)
+        if self.header_offset != self.header_offset_orig:
+            xs = str(xp + 1)
+        else:
+            xs = "{} {}".format(xp + 1, self.header[xp])
+        s = "  {},{}  ".format(ys, xs)
         addstr(self.scr, s, curses.A_REVERSE)
 
         # Adds the current cell content after the 'current cell' display


### PR DESCRIPTION
If we have column labels, by calculating the correct column width they are often truncated. Showing the full column label in the info bar is more convenient for me.

We could in theory only show it for cases when at least one header was truncated, but in practice after playing around with it it's better to have some consistency between runs.

Similarly, if we allow to have a row index in the future, having the full-length index name there makes sense.

Note that I already proposed to show "row name,column name" in issue #61. In reality, without having the row/column numbers visible, it's harder to move around. It's more convenient to always have them visible.

Comments?