### PR TITLE
Also ignore errors for use_default_colors().

### DIFF
--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -900,7 +900,10 @@ def detect_encoding(data=None):
 
 
 def main(stdscr, *args, **kwargs):
-    curses.use_default_colors()
+    try:
+        curses.use_default_colors()
+    except (AttributeError, _curses.error):
+        pass
     try:
         curses.curs_set(False)
     except (AttributeError, _curses.error):


### PR DESCRIPTION
If we support crappy terminals, we might as well support VT100, which is a pretty common baseline emulated by a lot of software. Nothing much to do, except ignore errors also for use_default_colors().