### PR TITLE
Add C-a/C-e as alternatives to line_home/line_end

### DIFF
--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -10,6 +10,7 @@ from __future__ import print_function, division, unicode_literals
 import csv
 import _curses
 import curses
+import curses.ascii
 import locale
 import os
 import re
@@ -535,6 +536,8 @@ class Viewer:
                      curses.KEY_IC:     self.mark,
                      curses.KEY_DC:     self.goto_mark,
                      curses.KEY_ENTER:  self.show_cell,
+                     curses.ascii.ctrl(b'a'):  self.line_home,
+                     curses.ascii.ctrl(b'e'):  self.line_end,
                      }
 
     def run(self):

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -25,6 +25,9 @@ if sys.version_info.major < 3:
     # Python 2.7 shim
     str = unicode
 
+    def CTRL(key):
+        return curses.ascii.ctrl(bytes(key))
+
     def addstr(*args):
         scr, args = args[0], list(args[1:])
         x = 2 if len(args) > 2 else 0
@@ -39,6 +42,9 @@ if sys.version_info.major < 3:
 
 else:
     # Python 3 wrappers
+    def CTRL(key):
+        return curses.ascii.ctrl(key)
+
     def addstr(*args):
         scr, args = args[0], args[1:]
         return scr.addstr(*args)
@@ -536,8 +542,8 @@ class Viewer:
                      curses.KEY_IC:     self.mark,
                      curses.KEY_DC:     self.goto_mark,
                      curses.KEY_ENTER:  self.show_cell,
-                     curses.ascii.ctrl(b'a'):  self.line_home,
-                     curses.ascii.ctrl(b'e'):  self.line_end,
+                     CTRL('a'):  self.line_home,
+                     CTRL('e'):  self.line_end,
                      }
 
     def run(self):


### PR DESCRIPTION
I'm not against adding some common bindings.
C-a/C-e are just aliases for line_home/line_end. Why not?

There's no other common emacs-like binding we could directly map right now (C-s/C-r do not map really well, and C-SPC (for mark) would have no "C-x C-x" (for jump to mark).