### PR TITLE
Mitigate performance impact of double width characters

### DIFF
--- a/bin/tabview
+++ b/bin/tabview
@@ -46,6 +46,9 @@ def arg_parse():
                         help="Specify column width. 'max' or 'mode' (default) "
                         "for variable widths, or an integer value for "
                         "fixed column width.")
+    parser.add_argument('--double_width', action='store_true',
+                        help="Force full handling of double-width characters "
+                        "for large files (with a performance penalty)")
     return parser.parse_known_args()
 
 
@@ -82,4 +85,4 @@ if __name__ == '__main__':
     pos_plus = [i for i in extra if i.startswith('+')]
     start_pos = start_position(args.start_pos, pos_plus)
     view(args.filename, enc=args.encoding, start_pos=start_pos,
-         column_width=args.width)
+         column_width=args.width, double_width=args.double_width)

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -96,7 +96,9 @@ class Viewer:
             self.header_offset = self.header_offset_orig - 1
         self.num_data_columns = len(self.data[0])
 
-        self.double_width = kwargs['double_width']
+        self.double_width = kwargs.get('double_width')
+        if self.double_width is None:
+            self.double_width = (len(self.data) * self.num_data_columns) < 256 ** 2
         if self.double_width:
             self._cell_len = self._cell_len_dw
         else:
@@ -1024,8 +1026,6 @@ def view(data, enc=None, start_pos=(0, 0), column_width=20, column_gap=2,
                 except TypeError:
                     d = data
                 d = process_data(d, enc)
-                if double_width == None:
-                    double_width = len(d) < 1 or (len(d) * len(d[0])) < 256 ** 2
                 curses.wrapper(main, d,
                                start_pos=start_pos,
                                column_width=column_width,

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -77,7 +77,7 @@ class Viewer:
             stdscr, data
         kwargs: dict of other keyword arguments.
             start_pos, column_width, column_gap, trunc_char, column_widths,
-            search_str
+            search_str, double_width
 
     """
     def __init__(self, *args, **kwargs):
@@ -95,6 +95,13 @@ class Viewer:
             # Don't make one line file a header row
             self.header_offset = self.header_offset_orig - 1
         self.num_data_columns = len(self.data[0])
+
+        self.double_width = kwargs['double_width']
+        if self.double_width:
+            self._cell_len = self._cell_len_dw
+        else:
+            self._cell_len = self._cell_len_rw
+
         self.column_width_mode = kwargs['column_width']
         self.column_gap = kwargs['column_gap']
         if kwargs['column_widths'] is None or \
@@ -780,8 +787,12 @@ class Viewer:
             self.column_width = [width for i in
                                  range(0, self.num_data_columns)]
 
-    def _cell_len(self, s):
-        """Return the number of character cells a string will take"""
+    def _cell_len_rw(self, s):
+        """Return the number of character cells a string will take (regular version)"""
+        return len(s)
+
+    def _cell_len_dw(self, s):
+        """Return the number of character cells a string will take (double-width aware)"""
         len = 0
         for c in s:
             w = 2 if unicodedata.east_asian_width(c) == 'W' else 1
@@ -976,7 +987,7 @@ def main(stdscr, *args, **kwargs):
 
 
 def view(data, enc=None, start_pos=(0, 0), column_width=20, column_gap=2,
-         trunc_char='…', column_widths=None, search_str=None):
+         trunc_char='…', column_widths=None, search_str=None, double_width=None):
     """The curses.wrapper passes stdscr as the first argument to main +
     passes to main any other arguments passed to wrapper. Initializes
     and then puts screen back in a normal state after closing or
@@ -995,6 +1006,8 @@ def view(data, enc=None, start_pos=(0, 0), column_width=20, column_gap=2,
         column_widths: list of widths for each column [len1, len2, lenxxx...]
         trunc_char: character to indicate continuation of too-long columns
         search_str: string to search for
+        double_width: boolean indicating whether double-width characters
+                      should be handled (defaults to False for large files)
 
     """
     if sys.version_info.major < 3:
@@ -1011,13 +1024,16 @@ def view(data, enc=None, start_pos=(0, 0), column_width=20, column_gap=2,
                 except TypeError:
                     d = data
                 d = process_data(d, enc)
+                if double_width == None:
+                    double_width = len(d) < 1 or (len(d) * len(d[0])) < 256 ** 2
                 curses.wrapper(main, d,
                                start_pos=start_pos,
                                column_width=column_width,
                                column_gap=column_gap,
                                trunc_char=trunc_char,
                                column_widths=column_widths,
-                               search_str=search_str)
+                               search_str=search_str,
+                               double_width=double_width)
             except (QuitException, KeyboardInterrupt):
                 return 0
             except ReloadException as e:


### PR DESCRIPTION
Add a new 'double_width' keyword argument to Viewer to specify whether
double-width characters should be fully handled. Currently only disables exact
column width calculations, which is the major offender.

view() defaults the parameter to True for small files (less than 65k cells) or
False for anything larger.

The parameter can be overridden in tabview using the --double_width flag.