### PR TITLE
Support reading from stdin (fixes #79)

### DIFF
--- a/bin/tabview
+++ b/bin/tabview
@@ -18,6 +18,9 @@
 """
 from __future__ import print_function, unicode_literals
 import argparse
+import io
+import os
+import sys
 from tabview.tabview import readme, view
 
 
@@ -80,9 +83,26 @@ def start_position(start_norm, start_classic):
     return start_pos
 
 
+def fixup_stdin():
+    print("tabview: Reading from stdin...", file=sys.stderr)
+    buf = io.BytesIO()
+    if isinstance(sys.stdin, io.TextIOBase):
+        data = sys.stdin.buffer.read()
+    else:
+        data = sys.stdin.read()
+    os.dup2(os.open("/dev/tty", os.O_RDONLY), 0)
+    buf.write(data)
+    buf.seek(0)
+    return buf
+
+
 if __name__ == '__main__':
     args, extra = arg_parse()
     pos_plus = [i for i in extra if i.startswith('+')]
     start_pos = start_position(args.start_pos, pos_plus)
-    view(args.filename, enc=args.encoding, start_pos=start_pos,
+    if args.filename != '-':
+        data = args.filename
+    else:
+        data = fixup_stdin()
+    view(data, enc=args.encoding, start_pos=start_pos,
          column_width=args.width, double_width=args.double_width)

--- a/bin/tabview
+++ b/bin/tabview
@@ -18,7 +18,6 @@
 """
 from __future__ import print_function, unicode_literals
 import argparse
-import io
 import os
 import sys
 from tabview.tabview import readme, view
@@ -85,15 +84,9 @@ def start_position(start_norm, start_classic):
 
 def fixup_stdin():
     print("tabview: Reading from stdin...", file=sys.stderr)
-    buf = io.BytesIO()
-    if isinstance(sys.stdin, io.TextIOBase):
-        data = sys.stdin.buffer.read()
-    else:
-        data = sys.stdin.read()
+    data = os.fdopen(os.dup(0), 'rb');
     os.dup2(os.open("/dev/tty", os.O_RDONLY), 0)
-    buf.write(data)
-    buf.seek(0)
-    return buf
+    return data
 
 
 if __name__ == '__main__':

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -44,6 +44,7 @@ if sys.version_info.major < 3:
 
 else:
     basestring = str
+    file = io.FileIO
 
     # Python 3 wrappers
     def CTRL(key):
@@ -1042,7 +1043,7 @@ def view(data, enc=None, start_pos=(0, 0), column_width=20, column_gap=2,
                 if isinstance(data, basestring):
                     with open(data, 'rb') as fd:
                         new_data = fd.readlines()
-                elif isinstance(data, io.IOBase):
+                elif isinstance(data, (io.IOBase, file)):
                     new_data = data.readlines()
                 else:
                     new_data = data

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -12,6 +12,7 @@ import _curses
 import curses
 import curses.ascii
 import locale
+import io
 import os
 import re
 import sys
@@ -42,6 +43,8 @@ if sys.version_info.major < 3:
         return scr.insstr(*args)
 
 else:
+    basestring = str
+
     # Python 3 wrappers
     def CTRL(key):
         return curses.ascii.ctrl(key)
@@ -82,10 +85,7 @@ class Viewer:
     """
     def __init__(self, *args, **kwargs):
         self.scr = args[0]
-        if sys.version_info.major < 3:
-            self.data = args[1]
-        else:
-            self.data = [[str(j) for j in i] for i in args[1]]
+        self.data = [[str(j) for j in i] for i in args[1]]
         self.header_offset_orig = 3
         self.header = self.data[0]
         if len(self.data) > 1:
@@ -939,10 +939,7 @@ def data_list_or_file(data):
     Returns: 'file' if data was from a file, 'list' if from a python list/tuple
 
     """
-    try:
-        f = isinstance(data[0], basestring)
-    except NameError:
-        f = isinstance(data[0], bytes)
+    f = isinstance(data[0], (basestring, bytes))
     return 'file' if f is True else 'list'
 
 
@@ -1017,8 +1014,8 @@ def view(data, enc=None, start_pos=(0, 0), column_width=20, column_gap=2,
     exceptions.
 
     Args:
-        data: data (list of lists, tuple of tuples). Should be normalized to
-            equal row lengths
+        data: data (filename, file, list of lists or tuple of tuples).
+              Should be normalized to equal row lengths
         enc: encoding for file/data
         start_pos: initial file position. Either a single integer for just y
             (row) position, or tuple/list (y,x)
@@ -1039,15 +1036,27 @@ def view(data, enc=None, start_pos=(0, 0), column_width=20, column_gap=2,
     else:
         lc_all = None
     try:
+        buf = None
         while True:
             try:
-                try:
-                    with open(data, 'rb') as f:
-                        d = f.readlines()
-                except TypeError:
-                    d = data
-                d = process_data(d, enc)
-                curses.wrapper(main, d,
+                if isinstance(data, basestring):
+                    with open(data, 'rb') as fd:
+                        new_data = fd.readlines()
+                elif isinstance(data, io.IOBase):
+                    new_data = data.readlines()
+                else:
+                    new_data = data
+
+                if new_data:
+                    buf = process_data(new_data, enc)
+                elif buf:
+                    # cannot reload the file
+                    pass
+                else:
+                    # cannot read the file
+                    return 1
+
+                curses.wrapper(main, buf,
                                start_pos=start_pos,
                                column_width=column_width,
                                column_gap=column_gap,


### PR DESCRIPTION
In bin/tabview, support reading directly from stdin if the filename is '-'. In
that case, buffer the entire data into a BytesIO stream, then fix stdin by
re-opening the controlling terminal directly (assigning to sys.stdin is not
enough for the curses module).

In the tabview.view, support reading also from an IOBase object directly.
Rework the reload loop in order to ignore (for now) open/reload errors instead
of failing.