### PR TITLE
Improved command-line help (fixes #63)

### DIFF
--- a/bin/tabview
+++ b/bin/tabview
@@ -18,18 +18,16 @@
 """
 from __future__ import print_function, unicode_literals
 import argparse
-from tabview.tabview import readme, view
+from tabview.tabview import view
 
 
 def arg_parse():
-    """Parse filename and show help. Assumes README is in the same
-    directory as tabview.py
-
-    """
-    parser = argparse.ArgumentParser(formatter_class=
-                                     argparse.RawDescriptionHelpFormatter,
-                                     description="".join(readme()))
-    parser.add_argument('filename')
+    """Parse filename and show help."""
+    parser = argparse.ArgumentParser(description="View a tab-delimited file in "
+                        "a spreadsheet-like display. Press F1 or '?' while "
+                        "running for a list of available keybindings.")
+    parser.add_argument('filename', help="File to read. Use '-' to read from "
+                        "the standard input instead.")
     parser.add_argument('--encoding', '-e', help="Encoding, if required.  "
                         "If the file is UTF-8, Latin-1(iso8859-1) or a few "
                         "other common encodings, it should be detected "


### PR DESCRIPTION
A command-line help should be minimal: a description and usage of command line
flags, and nothing more. We point the user towards the built-in help for a list
of keybindings.