### PR TITLE
Add []{} motion commands to skip through value changes.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,4 +141,8 @@ Keybindings:
 **[num]c**                   Toggle variable column width mode (mode/max),
                              or set width to [num]
 **[num]C**                   Maximize current column, or set width to [num]
+**[num][**                   Skip to (nth) change in row value (backward)
+**[num]]**                   Skip to (nth) change in row value (forward)
+**[num]{**                   Skip to (nth) change in column value (backward)
+**[num]}**                   Skip to (nth) change in column value (forward)
 ==========================   =================================================

--- a/tabview/tabview.py
+++ b/tabview/tabview.py
@@ -557,6 +557,10 @@ class Viewer:
                      'r':   self.reload,
                      'c':   self.toggle_column_width,
                      'C':   self.set_current_column_width,
+                     ']':   self.skip_to_row_change,
+                     '[':   self.skip_to_row_change_reverse,
+                     '}':   self.skip_to_col_change,
+                     '{':   self.skip_to_col_change_reverse,
                      '?':   self.help,
                      curses.KEY_F1:     self.help,
                      curses.KEY_UP:     self.up,
@@ -866,6 +870,33 @@ class Viewer:
         d = zip(*d)
         return [max(1, min(250, max(set(self._cell_len(j) for j in i))))
                 for i in d]
+
+    def _skip_to_value_change(self, x_inc, y_inc):
+        m = self.consume_modifier()
+        for _ in range(m):
+            x = self.win_x + self.x
+            y = self.win_y + self.y
+            v = self.data[y][x]
+            y += y_inc
+            x += x_inc
+            while y >= 0 and y < len(self.data) \
+              and x >= 0 and x < self.num_data_columns \
+              and self.data[y][x] == v:
+                y += y_inc
+                x += x_inc
+            self.goto_yx(y + 1, x + 1)
+
+    def skip_to_row_change(self):
+        self._skip_to_value_change(0, 1)
+
+    def skip_to_row_change_reverse(self):
+        self._skip_to_value_change(0, -1)
+
+    def skip_to_col_change(self):
+        self._skip_to_value_change(1, 0)
+
+    def skip_to_col_change_reverse(self):
+        self._skip_to_value_change(-1, 0)
 
 
 def csv_sniff(data, enc):


### PR DESCRIPTION
Statistical data often contains categorical values. It's often handy to skip to
the next different value in a series instead of scrolling.

[] skips through the series (y axis), {} skips through the row (x) which is
usually less common.